### PR TITLE
list_handlers: Do not use directory modification time to detect changes

### DIFF
--- a/src/list_handler.erl
+++ b/src/list_handler.erl
@@ -15,28 +15,18 @@ init(_, Req, _Opts) ->
 
 handle(Req, State=#state{}) ->
     {ok, Directory} = application:get_env(trust_store_http, directory),
-    case modified(Req, Directory) of
-        {true, Mtime} ->
-            case list_files(Directory) of
-                {ok, Files}  -> respond(Mtime, Files, Req, State);
-                {error, Err} -> respond_error(Err, Req, State)
-            end;
-        false           -> respond_no_change(Req, State);
-        {error, Reason} -> respond_error(Reason, Req, State)
+    case list_files(Directory) of
+        {ok, Files}  -> respond(Files, Req, State);
+        {error, Err} -> respond_error(Err, Req, State)
     end.
 
 terminate(_Reason, _Req, _State) ->
     ok.
 
-respond(Mtime, Files, Req, State) ->
+respond(Files, Req, State) ->
     ResponseBody = json_encode(Files),
-    Headers = [{<<"Last-Modified">>, cowboy_clock:rfc1123(Mtime)},
-               {<<"content-type">>, <<"application/json">>}],
+    Headers = [{<<"content-type">>, <<"application/json">>}],
     {ok, Req2} = cowboy_req:reply(200, Headers, ResponseBody, Req),
-    {ok, Req2, State}.
-
-respond_no_change(Req, State) ->
-    {ok, Req2} = cowboy_req:reply(304, Req),
     {ok, Req2, State}.
 
 respond_error(Reason, Req, State) ->
@@ -46,18 +36,18 @@ respond_error(Reason, Req, State) ->
     {ok, Req2, State}.
 
 json_encode(Files) ->
-    Map = #{certificates => [ #{id   => cert_id(FileName, FileDate),
+    Map = #{certificates => [ #{id   => cert_id(FileName, FileDate, FileHash),
                                 path => cert_path(FileName)}
-                              || {FileName, FileDate} <- Files ]},
+                              || {FileName, FileDate, FileHash} <- Files ]},
     jsx:encode(Map).
 
-cert_id(FileName, FileDate) ->
-    iolist_to_binary(io_lib:format("~s:~p", [FileName, FileDate])).
+cert_id(FileName, FileDate, FileHash) ->
+    iolist_to_binary(io_lib:format("~s:~p:~p", [FileName, FileDate, FileHash])).
 
 cert_path(FileName) ->
     iolist_to_binary(["/certs/", FileName]).
 
--spec list_files(string()) -> [{string(), file:date_time()}].
+-spec list_files(string()) -> [{string(), file:date_time(), integer()}].
 list_files(Directory) ->
     case file:list_dir(Directory) of
         {ok, FileNames} ->
@@ -67,31 +57,12 @@ list_files(Directory) ->
                     fun(FileName) ->
                         FullName = filename:join(Directory, FileName),
                         {ok, Mtime} = modification_time(FullName, posix),
-                        {FileName, Mtime}
+                        Hash = file_content_hash(FullName),
+                        {FileName, Mtime, Hash}
                     end,
                     PemFiles)};
         {error, Err} -> {error, Err}
     end.
-
-modified(Req, Directory) ->
-    case modification_time(Directory, universal) of
-        {ok, Mtime} ->
-            {ok, HeaderTime, _Req} =
-                cowboy_req:parse_header(<<"if-modified-since">>, Req),
-            case date_later(Mtime, HeaderTime) of
-                true ->
-                    {true, Mtime};
-                false ->
-                    false
-            end;
-        {error, Reason} -> {error, Reason}
-    end.
-
-date_later(_Mtime, undefined) -> true;
-date_later(Mtime = {{_,_,_},{_,_,_}}, OldTime = {{_,_,_},{_,_,_}}) ->
-    MtimeSec = calendar:datetime_to_gregorian_seconds(Mtime),
-    OldTimeSec = calendar:datetime_to_gregorian_seconds(OldTime),
-    MtimeSec > OldTimeSec.
 
 modification_time(FileName, Type) ->
     case file:read_file_info(FileName, [{time, Type}]) of
@@ -99,12 +70,6 @@ modification_time(FileName, Type) ->
         {error, Reason} -> {error, Reason}
     end.
 
-
-
-
-
-
-
-
-
-
+file_content_hash(Path) ->
+    {ok, Data} = file:read_file(Path),
+    erlang:phash2(Data).


### PR DESCRIPTION
The directory modification time is unreliable for this particular use because:

* It is only updated when a file is added, renamed or removed, not when a file's content changes.
* The time resolution is not be precise enough: the filesystem may have a one-second resolution and the Erlang API has also a one-second resolution.

This led to certificate updates being undetected.

Fixes #1.